### PR TITLE
fix: 🐛 Upload Proxy failing Authorization

### DIFF
--- a/.changeset/neat-pears-lick.md
+++ b/.changeset/neat-pears-lick.md
@@ -1,0 +1,5 @@
+---
+'@fleek-platform/sdk': patch
+---
+
+Fix Upload Proxy failing Authorization headers for Delete

--- a/src/clients/uploadProxy.ts
+++ b/src/clients/uploadProxy.ts
@@ -290,7 +290,7 @@ export class UploadProxyClient {
     return fetch(url, {
       method: 'DELETE',
       headers: {
-        Authorization: ` ${accessToken}`,
+        Authorization: `Bearer ${accessToken}`,
       },
     });
   };


### PR DESCRIPTION
## Why?

Upload Proxy failing Authorization

## How?

- Change upload proxy auth headers

## Tickets?

- [PLAT-1736](https://linear.app/fleekxyz/issue/PLAT-1736/storage-delete-fails-due-to-upload-proxy-failing-authorization

## Contribution checklist?

- [x] The commit messages are detailed
- [x] The `build` command runs locally
- [ ] Assets or static content are linked and stored in the project
- [ ] You have manually tested
- [ ] You have provided tests

## Security checklist?

- [ ] Sensitive data has been identified and is being protected properly
- [ ] Injection has been prevented (parameterized queries, no eval or system calls)

## Preview?

Optionally, provide the preview url here
